### PR TITLE
add zio-grpc-core to tracked projects

### DIFF
--- a/shared/src/main/scala/org/ziverge/TrackedProjects.scala
+++ b/shared/src/main/scala/org/ziverge/TrackedProjects.scala
@@ -123,6 +123,7 @@ object TrackedProjects:
         ),
         Project("io.github.neurodyne", "zio-arrow", Some("https://github.com/zio-mesh/zio-arrow")),
         Project("dev.akif", "e-zio", Some("https://github.com/makiftutuncu/e")),
+        Project("com.thesamet.scalapb.zio-grpc", "zio-grpc-core", Some("https://github.com/scalapb/zio-grpc")),
         // TODO Figure out how to get weaver-zio to show the ZIO dependency for weaver-zio-core
 //        Project("com.disneystreaming", "weaver-zio", Some("https://github.com/disneystreaming/weaver-test")),
 //        Project("com.disneystreaming", "weaver-zio-core", Some("https://github.com/disneystreaming/weaver-test")),


### PR DESCRIPTION
Thanks for creating this tracker!

This change adds `zio-grpc-core` to the list of tracked projects.

I see that #9 also adds zio-grpc, but the dependency it adds (`zio-grpc-codegen`) does not have a direct dependency on ZIO so it may be difficult to determine it's ZIO 2.x adoption status. `zio-grpc-core` directly depends on ZIO core, which should provide an accurate reflection of adoption status.